### PR TITLE
Fix testnet

### DIFF
--- a/src/activefundamentalnode.cpp
+++ b/src/activefundamentalnode.cpp
@@ -218,7 +218,7 @@ bool CActiveFundamentalnode::SendFundamentalnodePing(std::string& errorMessage)
         LogPrint("fundamentalnode", "dseep - relaying from active fn, %s \n", vin.ToString().c_str());
         LOCK(cs_vNodes);
         for (CNode* pnode : vNodes)
-            pnode->PushMessage("dseep", vin, vchFundamentalNodeSignature, fundamentalNodeSignatureTime, false);
+            pnode->PushMessage("obseep", vin, vchFundamentalNodeSignature, fundamentalNodeSignatureTime, false);
 
         /*
          * END OF "REMOVE"
@@ -325,7 +325,7 @@ bool CActiveFundamentalnode::CreateBroadcast(CTxIn vin, CService service, CKey k
 
     LOCK(cs_vNodes);
     for (CNode* pnode : vNodes)
-        pnode->PushMessage("dsee", vin, service, vchFundamentalNodeSignature, fundamentalNodeSignatureTime, pubKeyCollateralAddress, pubKeyFundamentalnode, -1, -1, fundamentalNodeSignatureTime, PROTOCOL_VERSION, donationAddress, donationPercantage);
+        pnode->PushMessage("obsee", vin, service, vchFundamentalNodeSignature, fundamentalNodeSignatureTime, pubKeyCollateralAddress, pubKeyFundamentalnode, -1, -1, fundamentalNodeSignatureTime, PROTOCOL_VERSION, donationAddress, donationPercantage);
 
     /*
      * END OF "REMOVE"

--- a/src/fundamentalnode.cpp
+++ b/src/fundamentalnode.cpp
@@ -71,7 +71,6 @@ CFundamentalnode::CFundamentalnode() :
     cacheInputAgeBlock = 0;
     unitTest = false;
     allowFreeTx = true;
-    nActiveState = FUNDAMENTALNODE_ENABLED,
     protocolVersion = PROTOCOL_VERSION;
     nLastDsq = 0;
     nScanningErrorCount = 0;
@@ -96,7 +95,6 @@ CFundamentalnode::CFundamentalnode(const CFundamentalnode& other) :
     cacheInputAgeBlock = other.cacheInputAgeBlock;
     unitTest = other.unitTest;
     allowFreeTx = other.allowFreeTx;
-    nActiveState = FUNDAMENTALNODE_ENABLED,
     protocolVersion = other.protocolVersion;
     nLastDsq = other.nLastDsq;
     nScanningErrorCount = other.nScanningErrorCount;
@@ -296,9 +294,9 @@ int64_t CFundamentalnode::GetLastPaid()
     return 0;
 }
 
-std::string CFundamentalnode::GetStatus()
+std::string CFundamentalnode::Status()
 {
-    switch (nActiveState) {
+    switch (activeState) {
         case CFundamentalnode::FUNDAMENTALNODE_PRE_ENABLED:
             return "PRE_ENABLED";
         case CFundamentalnode::FUNDAMENTALNODE_ENABLED:
@@ -315,6 +313,10 @@ std::string CFundamentalnode::GetStatus()
             return "POSE_BAN";
         case CFundamentalnode::FUNDAMENTALNODE_MISSING:
             return "MISSING";
+        case CFundamentalnode::FUNDAMENTALNODE_VIN_SPENT:
+            return "VIN_SPENT";
+        case CFundamentalnode::FUNDAMENTALNODE_POS_ERROR:
+            return "POS_ERROR";
         default:
             return "UNKNOWN";
     }

--- a/src/fundamentalnode.h
+++ b/src/fundamentalnode.h
@@ -142,7 +142,6 @@ public:
     bool unitTest;
     bool allowFreeTx;
     int protocolVersion;
-    int nActiveState;
     int64_t nLastDsq; //the dsq count from the last dsq broadcast of this node
     int nScanningErrorCount;
     int nLastScanningErrorBlockHeight;
@@ -275,21 +274,7 @@ public:
         return cacheInputAge + (chainActive.Tip()->nHeight - cacheInputAgeBlock);
     }
 
-    std::string GetStatus();
-
-    std::string Status()
-    {
-        std::string strStatus = "ACTIVE";
-
-        if (activeState == CFundamentalnode::FUNDAMENTALNODE_ENABLED) strStatus = "ENABLED";
-        if (activeState == CFundamentalnode::FUNDAMENTALNODE_EXPIRED) strStatus = "EXPIRED";
-        if (activeState == CFundamentalnode::FUNDAMENTALNODE_VIN_SPENT) strStatus = "VIN_SPENT";
-        if (activeState == CFundamentalnode::FUNDAMENTALNODE_REMOVE) strStatus = "REMOVE";
-        if (activeState == CFundamentalnode::FUNDAMENTALNODE_POS_ERROR) strStatus = "POS_ERROR";
-        if (activeState == CFundamentalnode::FUNDAMENTALNODE_MISSING) strStatus = "MISSING";
-
-        return strStatus;
-    }
+    std::string Status();
 
     int64_t GetLastPaid();
     bool IsValidNetAddr();

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -206,7 +206,7 @@ void MasternodeList::updateMyMasternodeInfo(QString strAlias, QString strAddr, C
     QTableWidgetItem* aliasItem = new QTableWidgetItem(strAlias);
     QTableWidgetItem* addrItem = new QTableWidgetItem(pmn ? QString::fromStdString(pmn->addr.ToString()) : strAddr);
     QTableWidgetItem* protocolItem = new QTableWidgetItem(QString::number(pmn ? pmn->protocolVersion : -1));
-    QTableWidgetItem* statusItem = new QTableWidgetItem(QString::fromStdString(pmn ? pmn->GetStatus() : "MISSING"));
+    QTableWidgetItem* statusItem = new QTableWidgetItem(QString::fromStdString(pmn ? pmn->Status() : "MISSING"));
     GUIUtil::DHMSTableWidgetItem* activeSecondsItem = new GUIUtil::DHMSTableWidgetItem(pmn ? (pmn->lastPing.sigTime - pmn->sigTime) : 0);
     QTableWidgetItem* lastSeenItem = new QTableWidgetItem(QString::fromStdString(DateTimeStrFormat("%Y-%m-%d %H:%M", pmn ? pmn->lastPing.sigTime : 0)));
     QTableWidgetItem* pubkeyItem = new QTableWidgetItem(QString::fromStdString(pmn ? CBitcoinAddress(pmn->pubKeyCollateralAddress.GetID()).ToString() : ""));
@@ -550,7 +550,7 @@ void MasternodeList::updateMyFundamentalNodeInfo(QString strAlias, QString strAd
     QTableWidgetItem* aliasItem = new QTableWidgetItem(strAlias);
     QTableWidgetItem* addrItem = new QTableWidgetItem(pmn ? QString::fromStdString(pmn->addr.ToString()) : strAddr);
     QTableWidgetItem* protocolItem = new QTableWidgetItem(QString::number(pmn ? pmn->protocolVersion : -1));
-    QTableWidgetItem* statusItem = new QTableWidgetItem(QString::fromStdString(pmn ? pmn->GetStatus() : "MISSING"));
+    QTableWidgetItem* statusItem = new QTableWidgetItem(QString::fromStdString(pmn ? pmn->Status() : "MISSING"));
     GUIUtil::DHMSTableWidgetItem* activeSecondsItem = new GUIUtil::DHMSTableWidgetItem(pmn ? (pmn->lastPing.sigTime - pmn->sigTime) : 0);
     QTableWidgetItem* lastSeenItem = new QTableWidgetItem(QString::fromStdString(DateTimeStrFormat("%Y-%m-%d %H:%M", pmn ? pmn->lastPing.sigTime : 0)));
     QTableWidgetItem* pubkeyItem = new QTableWidgetItem(QString::fromStdString(pmn ? CBitcoinAddress(pmn->pubKeyCollateralAddress.GetID()).ToString() : ""));


### PR DESCRIPTION
Fixed two serious problems,
1, There are duplicate state variable nActiveState and activeState in CFundamentalnode, and duplicated function GetStatus and Status, and nActiveState is never set properly. That cause the 'status' column in the fundamental list in the UI is never correct.
Now the duplicated states and functions are removed.
2, The class CActiveFundamentalnode sends message dsee and dseep, which are messages for masternode. Now the messages are changed to correct names, obsee and obseep.
